### PR TITLE
User's note for noteupdate (line 238)

### DIFF
--- a/floppy-nocall.py
+++ b/floppy-nocall.py
@@ -235,7 +235,7 @@ else:
 
 
 ## User asked if they'd like to update the notes they entered
-noteupdate = input(bcolors.INPUT+"If you would like to update the disk notes (currently: "+bcolors.OKGREEN+str(note)+bcolors.ENDC+bcolors.INPUT+"), please re-enter, otherwise hit Enter: "+bcolors.ENDC)
+noteupdate = input(bcolors.INPUT+"If you would like to update the disk notes (currently: "+bcolors.OKGREEN+str(note)+bcolors.ENDC+bcolors.INPUT+"), please re-enter, otherwise hit Enter (Note: input i4 for MFM format and i9 for Apple DOS 400k/800k format): "+bcolors.ENDC)
 if noteupdate:
 	note = noteupdate
 	print("-Note has been updated to: " + bcolors.OKGREEN + str(note) + bcolors.ENDC)


### PR DESCRIPTION
Added "(Note: input i4 for MFM format and i9 for Apple DOS 400k/800k format)" to line 238 to remind users that `i4` for MFM and `i9` for Apple format should be inputted.

See P.29 for -i {types} https://docs.google.com/document/d/1LViSnYpvr2jf1TrCh6ELuL-FWo14ICw-WZeb8j5GGpU/edit